### PR TITLE
make it work with current rakudo

### DIFF
--- a/lib/XML/SAX/Grammar.pm
+++ b/lib/XML/SAX/Grammar.pm
@@ -1,15 +1,21 @@
 grammar XML::SAX::Grammar;
 
-regex TOP { ^ [ \s* <opening> || \s* <closing> || \s* <single> || <text>
-	|| \s* <comment> ] }
+token TOP {
+    ^   [
+        || \s* <opening>
+        || \s* <closing>
+        || \s* <single>
+        || <text>
+        || \s* <comment>
+        ]
+}
 
 token element { \w+ }
 token name    { \w+ }
 token value   { <-[\"]>* }
-rule  attr    { [<name>\=\"<value>\"] }
-rule  text    { <-[\<]>+ <?before \< > }
-regex opening { \< <element> <attr>* \> }
-regex closing { \<\/ <element> \> }
-regex single  { \< <element> <attr>* \/\> }
-
-regex comment { \<\!\-\- .*? \-\-\> }
+token attr    { <.ws> <name> '="' <value> '"' <.ws> }
+token text    { <-[\<]>+ <?[\<]> }
+token opening { '<' <.ws> <element> <attr>* '>' }
+token closing { '<' <.ws> '/' <.ws> <element> <.ws> '>' }
+token single  { '<' <.ws> <element> <attr>* '/' <.ws> '>' }
+token comment { '<!--' .*? '-->' }


### PR DESCRIPTION
This covers the sigspace fixes which got applied to rakudo this year. Also it is better to use tokens since we know where we have to care about whitespace.
